### PR TITLE
Fixing version and deprecated terms

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,5 @@
-engines:
+version: "2"
+plugins:
   # https://docs.codeclimate.com/docs/eslint
   # ES Linting requires an .eslintrc file to tweak checks.
   eslint:
@@ -105,18 +106,8 @@ engines:
       - todo
       - dpm
       - dsm
-ratings:
-  paths:
-  - "**.inc"
-  - "**.module"
-  - "**.profile"
-  - "**.php"
-  - "**.install"
-  - "**.scss"
-  - "**.sass"
-  - "**.js"
 # exclude these files/paths
-exclude_paths:
+exclude_patterns:
 - "**.features.**"
 - "**.views_default.inc"
 - "**.field_group.inc"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix these issues in the .codeclimate.yml file

> codeclimate validate-config
> ERROR: only use one of 'exclude_paths', 'exclude_patterns'
> WARNING: missing 'version' key. Please add `version: "2"`
> WARNING: 'engines' has been deprecated, please use 'plugins' instead
> WARNING: 'exclude_paths' has been deprecated, please use 'exclude_patterns' instead
> WARNING: 'ratings' has been deprecated, and will not be used

# Needed By (Date)
- No particular date needed.

# Affected Projects or Products